### PR TITLE
Fix reading negative temperatures.

### DIFF
--- a/src/DHT22.cpp
+++ b/src/DHT22.cpp
@@ -83,10 +83,14 @@ void TDHT22::Fetch(void)
         Valid= true;
         Hum  = (float)((data[0] << 8) + data[1]) / 10.0;
         Temp = (float)((data[2] << 8) + data[3]) / 10.0;
-        if(data[2] & 0x80)  Temp *= -1;         // Negative Sign Bit on.
-        if(Fh){ Temp *= 1.8; Temp += 32.0; }    // Convert to Fahrenheit
+        if(data[2] & 0x80) {  // Negative Sign Bit on.
+	    Temp *= (float) -((((data[2] & 0x7F) << 8) + data[3]) / 10.0);
+	}
+        if(Fh) {  // Convert to Fahrenheit
+	    Temp *= 1.8; Temp += 32.0; 
+	}
     }
-    else {                                      // Data Bad, use cached values.
+    else {                 // Data Bad, use cached values.
         Valid= false;
         Hum  = 0.0;
         Temp = 0.0;


### PR DESCRIPTION
When the negative bit set, the original codes negate the result without eliminating the value of the sign bit.